### PR TITLE
Fix supabase client export

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext, createContext } from 'react';
-import supabase from '../utils/supabaseClient';
+import { supabase } from '../utils/supabaseClient';
 
 const AuthContext = createContext();
 

--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -12,3 +12,5 @@ const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey)
+
+export default supabase


### PR DESCRIPTION
## Summary
- fix named import usage in `useAuth`
- export default in `supabaseClient`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882dedf7cc88332953b45c2b471cb6e