### PR TITLE
Remove outdated Japanese comments

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -8,13 +8,13 @@ export const AuthProvider = ({ children }) => {
 
   useEffect(() => {
     const getSession = async () => {
-      const { data: { session } } = await supabase.auth.getSession(); // getSessionの使用法を修正
+      const { data: { session } } = await supabase.auth.getSession();
       setUser(session?.user ?? null);
     };
 
     getSession();
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => { // onAuthStateChangeの使用法を修正
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       setUser(session?.user ?? null);
     });
 


### PR DESCRIPTION
## Summary
- remove obsolete Japanese comments about `getSession` and `onAuthStateChange`

## Testing
- `npx next lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6882e55bcb5c833281dea201cdd72d97