### PR TITLE
Fix README code block and cleanup auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Welcome to the DauberSide Project. This project is deployed using Vercel and uti
 
 To start the development server, run:
 
-````sh
+```sh
 npm run dev
+```
 
 ### 手順2: プロジェクトの整理
 以下のようにディレクトリ構造を整理し、必要なファイルを適切な場所に配置します。
@@ -73,4 +74,4 @@ dauberside.github.io/
 git add .
 git commit -m "Add README.md and organize project structure"
 git push origin master
-````
+```

--- a/__mocks__/embla-carousel-react.js
+++ b/__mocks__/embla-carousel-react.js
@@ -1,26 +1,2 @@
-import useEmblaCarousel from "embla-carousel-react";
-
-const isTestEnvironment = process.env.NODE_ENV === "test";
-
-{
-  !isTestEnvironment && (
-    <Carousel className="w-full mx-auto">{/* Carousel の内容 */}</Carousel>
-  );
-}
-
-describe("Dauber Page", () => {
-  it("checks if embla-carousel is mocked", () => {
-    console.log(useEmblaCarousel()); // モックが適用されている場合、[null, {}] が出力される
-  });
-});
-
 const useEmblaCarousel = () => [null, {}];
 export default useEmblaCarousel;
-
-module.exports = {
-  moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/src/$1",
-    "embla-carousel-react": "<rootDir>/__mocks__/embla-carousel-react.js",
-  },
-  testEnvironment: "jsdom",
-};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.5.2",

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -2,13 +2,17 @@
 import { supabase } from "./supabaseClient";
 import bcrypt from "bcryptjs";
 
-const { error } = await supabase.auth.api.setCustomConfig({
-  otp_expiry: auth.otp_expiry(),
-});
+export const setOtpExpiry = async (expiry) => {
+  const { error } = await supabase.auth.api.setCustomConfig({
+    otp_expiry: expiry,
+  });
 
-if (error) {
-  console.error("Error setting OTP expiry:", error.message);
-}
+  if (error) {
+    console.error("Error setting OTP expiry:", error.message);
+  }
+
+  return { error };
+};
 
 export const signUpUser = async (email, password, username) => {
   const passwordHash = await bcrypt.hash(password, 10);


### PR DESCRIPTION
## Summary
- fix malformed code fences in `README.md`
- add missing `test` script to `package.json`
- simplify mock for `embla-carousel-react`
- rewrite `src/utils/auth.js` to remove top-level await

## Testing
- `npx jest --runInBand` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688363e35828833284158d87a0c3bf99